### PR TITLE
Retry after failure

### DIFF
--- a/lib/unique_thread.rb
+++ b/lib/unique_thread.rb
@@ -27,6 +27,7 @@ class UniqueThread
           yield
         rescue StandardError => error
           report_error(error)
+          retry
         end
       end
     end


### PR DESCRIPTION
## Example:
```
UniqueThread.new('my_lock').run do
  loop do
    run_some_thing_that_could_fail_from_time_to_time
    sleep(10)
  end
end
```
## Problem:
When the block I provide to UniqueThread fails, UniqueThread continues acquiring the lock. But the block I provide stops running.

## Proposal:
Continue handling, and reporting errors, but retry the block after failure.

Future improvements could have the locksmith monitor the worker thread, and do something when the worker thread dies.
